### PR TITLE
Add System/Inputs/Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 
+## [1.2.0]
+
+### Added
+
+- Get info about input types
+- Use name of type then create an input
+
+### Changed
+
+- Rename Client.json_request to Client.request
+
 ## Released
 
 ## [1.1.0] - 2017-08-14
 
 ### Added
+
 - Manage dashboards
 - Manage static fields of inputs
 - Update and make default methods for System/IndexSets

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For example, you can find *Inputs* in *System/Inputs* in the UI and you can find
 
 ### get Input by id
 
-    graylogapi = Graylog.new('http://localhost:9000/api', 'username', 'password')
+    graylogapi = Graylog.new(base_url: 'http://localhost:9000/api', user: 'username', pass: 'password')
     graylogapi.system.inputs.by_id('5947d3840b5712166af25009')
 
 ## Supported methods
@@ -80,6 +80,12 @@ For example, you can find *Inputs* in *System/Inputs* in the UI and you can find
   * create(params) — Launch input on this node.
   * update(params) — Update input on this node.
   * delete(id) — Terminate input on this node.
+* **System/Inputs/Types**: Message input types of this node.
+  * node — Get all available input types of this node.
+  * all — Get informatino about all input types.
+  * by_type(type) — Get information about a single input type.
+  * name_to_type(name) — Convert name of type to type.
+
 
 ## Copyright
 

--- a/lib/graylogapi/system/inputs.rb
+++ b/lib/graylogapi/system/inputs.rb
@@ -27,7 +27,7 @@ class GraylogAPI
       # @param params [Hash]
       # @return [GraylogAPI::Client::Response]
       def create(params = {})
-        @client.request(:post, '/system/inputs', params)
+        @client.request(:post, '/system/inputs', parse(params))
       end
 
       # update input
@@ -35,15 +35,15 @@ class GraylogAPI
       # @param params [Hash]
       # @return [GraylogAPI::Client::Response]
       def update(id, params = {})
-        @client.request(:put, "/system/inputs/#{id}", params)
+        @client.request(:put, "/system/inputs/#{id}", parse(params))
       end
 
       # delete input
       #
       # @param params [Hash]
       # @return [GraylogAPI::Client::Response]
-      def delete(id, params = {})
-        @client.request(:delete, "/system/inputs/#{id}", params)
+      def delete(id)
+        @client.request(:delete, "/system/inputs/#{id}")
       end
 
       # object for get information about input types
@@ -51,6 +51,29 @@ class GraylogAPI
       # @return [GraylogAPI::System::Inputs::Types]
       def types
         @types ||= Types.new(@client)
+      end
+
+      private
+
+      # parase params
+      #
+      # @return [Hash]
+      def parse(params)
+        if params.has_key? :type_name
+          params = type_name_to_type(params)
+        end
+
+        params
+      end
+
+      # convert type name to type
+      #
+      # @return [Hash]
+      def type_name_to_type(params)
+        type = types.name_to_type(params[:type_name])
+        params[:type] = type
+        params.delete(:type_name)
+        params
       end
     end
   end

--- a/lib/graylogapi/system/inputs.rb
+++ b/lib/graylogapi/system/inputs.rb
@@ -59,9 +59,7 @@ class GraylogAPI
       #
       # @return [Hash]
       def parse(params)
-        if params.has_key? :type_name
-          params = type_name_to_type(params)
-        end
+        params = type_name_to_type(params) if params.key? :type_name
 
         params
       end

--- a/lib/graylogapi/system/inputs.rb
+++ b/lib/graylogapi/system/inputs.rb
@@ -1,3 +1,5 @@
+require 'graylogapi/system/inputs/types'
+
 class GraylogAPI
   class System
     # class for manage inputs
@@ -42,6 +44,13 @@ class GraylogAPI
       # @return [GraylogAPI::Client::Response]
       def delete(id, params = {})
         @client.request(:delete, "/system/inputs/#{id}", params)
+      end
+
+      # object for get information about input types
+      #
+      # @return [GraylogAPI::System::Inputs::Types]
+      def types
+        @types ||= Types.new(@client)
       end
     end
   end

--- a/lib/graylogapi/system/inputs/types.rb
+++ b/lib/graylogapi/system/inputs/types.rb
@@ -1,6 +1,7 @@
 class GraylogAPI
   class System
     class Inputs
+      # class for getting info about input types
       class Types
         def initialize(client)
           @client = client
@@ -31,7 +32,7 @@ class GraylogAPI
         #
         # @return [String]
         def name_to_type(name)
-          all.body.find { |_, type| type['name'].downcase == name.downcase }.first
+          all.body.find { |_, type| type['name'].casecmp(name).zero? }.first
         end
       end
     end

--- a/lib/graylogapi/system/inputs/types.rb
+++ b/lib/graylogapi/system/inputs/types.rb
@@ -1,0 +1,32 @@
+class GraylogAPI
+  class System
+    class Inputs
+      class Types
+        def initialize(client)
+          @client = client
+        end
+
+        # get input types of current node
+        #
+        # @return [GraylogAPI::Client::Response]
+        def node
+          @client.request(:get, '/system/inputs/types')
+        end
+
+        # get all input types
+        #
+        # @return [GraylogAPI::Client::Response]
+        def all
+          @client.request(:get, '/system/inputs/types/all')
+        end
+
+        # get info about input type
+        #
+        # @return [GraylogAPI::Client::Response]
+        def by_type(type)
+          @client.request(:get, "/system/inputs/types/#{type}")
+        end
+      end
+    end
+  end
+end

--- a/lib/graylogapi/system/inputs/types.rb
+++ b/lib/graylogapi/system/inputs/types.rb
@@ -26,6 +26,13 @@ class GraylogAPI
         def by_type(type)
           @client.request(:get, "/system/inputs/types/#{type}")
         end
+
+        # convert type name to type
+        #
+        # @return [String]
+        def name_to_type(name)
+          all.body.find { |_, type| type['name'].downcase == name.downcase }.first
+        end
       end
     end
   end

--- a/spec/fixtures/vcr/GraylogAPI_System_Inputs/create_input_with_type_name_insted_of_type/code_201.yml
+++ b/spec/fixtures/vcr/GraylogAPI_System_Inputs/create_input_with_type_name_insted_of_type/code_201.yml
@@ -1,0 +1,485 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9000/api/system/inputs/types/all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '1269'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 27 Aug 2017 19:49:31 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"org.graylog2.inputs.gelf.udp.GELFUDPInput":{"type":"org.graylog2.inputs.gelf.udp.GELFUDPInput","name":"GELF
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.amqp.SyslogAMQPInput":{"type":"org.graylog2.inputs.syslog.amqp.SyslogAMQPInput","name":"Syslog
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.kafka.GELFKafkaInput":{"type":"org.graylog2.inputs.gelf.kafka.GELFKafkaInput","name":"GELF
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.udp.SyslogUDPInput":{"type":"org.graylog2.inputs.syslog.udp.SyslogUDPInput","name":"Syslog
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.tcp.SyslogTCPInput":{"type":"org.graylog2.inputs.syslog.tcp.SyslogTCPInput","name":"Syslog
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.misc.jsonpath.JsonPathInput":{"type":"org.graylog2.inputs.misc.jsonpath.JsonPathInput","name":"JSON
+        path from HTTP API","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"target_url":{"human_name":"URI
+        of JSON resource","additional_info":{},"description":"HTTP resource returning
+        JSON on GET","default_value":"http://example.org/api","attributes":[],"type":"text","is_optional":false},"headers":{"human_name":"Additional
+        HTTP headers","additional_info":{},"description":"Add a comma separated list
+        of additional HTTP headers. For example: Accept: application/json, X-Requester:
+        Graylog","default_value":"","attributes":[],"type":"text","is_optional":true},"interval":{"human_name":"Interval","additional_info":{},"description":"Time
+        between every collector run. Select a time unit in the corresponding dropdown.
+        Example: Run every 5 minutes.","default_value":1,"attributes":[],"type":"number","is_optional":false},"timeunit":{"human_name":"Interval
+        time unit","additional_info":{"values":{"MILLISECONDS":"Milliseconds","MICROSECONDS":"Microseconds","HOURS":"Hours","SECONDS":"Seconds","NANOSECONDS":"Nanoseconds","DAYS":"Days","MINUTES":"Minutes"}},"description":null,"default_value":"MINUTES","attributes":[],"type":"dropdown","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"path":{"human_name":"JSON
+        path of data to extract","additional_info":{},"description":"Path to the value
+        you want to extract from the JSON response. Take a look at the documentation
+        for a more detailed explanation.","default_value":"$.store.book[1].number_of_orders","attributes":[],"type":"text","is_optional":false},"source":{"human_name":"Message
+        source","additional_info":{},"description":"What to use as source field of
+        the resulting message.","default_value":"yourapi","attributes":[],"type":"text","is_optional":false}},"link_to_docs":"http://docs.graylog.org/en/2.2/pages/sending_data.html#json-path-from-http-api-input","is_exclusive":false},"org.graylog2.inputs.raw.tcp.RawTCPInput":{"type":"org.graylog2.inputs.raw.tcp.RawTCPInput","name":"Raw/Plaintext
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5555,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.tcp.GELFTCPInput":{"type":"org.graylog2.inputs.gelf.tcp.GELFTCPInput","name":"GELF
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.udp.RawUDPInput":{"type":"org.graylog2.inputs.raw.udp.RawUDPInput","name":"Raw/Plaintext
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5555,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.random.FakeHttpMessageInput":{"type":"org.graylog2.inputs.random.FakeHttpMessageInput","name":"Random
+        HTTP message generator","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"sleep":{"human_name":"Sleep
+        time","additional_info":{},"description":"How many milliseconds to sleep between
+        generating messages.","default_value":25,"attributes":["only_positive"],"type":"number","is_optional":false},"sleep_deviation":{"human_name":"Maximum
+        random sleep time deviation","additional_info":{},"description":"The deviation
+        is used to generate a more realistic and non-steady message flow.","default_value":30,"attributes":["only_positive"],"type":"number","is_optional":false},"source":{"human_name":"Source
+        name","additional_info":{},"description":"What to use as source of the generate
+        messages.","default_value":"example.org","attributes":[],"type":"text","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.http.GELFHttpInput":{"type":"org.graylog2.inputs.gelf.http.GELFHttpInput","name":"GELF
+        HTTP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"enable_cors":{"human_name":"Enable
+        CORS","additional_info":{},"description":"Input sends CORS headers to satisfy
+        browser security policies","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"max_chunk_size":{"human_name":"Max.
+        HTTP chunk size","additional_info":{},"description":"The maximum HTTP chunk
+        size in bytes (e. g. length of HTTP request body)","default_value":65536,"attributes":[],"type":"number","is_optional":true},"idle_writer_timeout":{"human_name":"Idle
+        writer timeout","additional_info":{},"description":"The server closes the
+        connection after the given time in seconds after the last client write request.
+        (use 0 to disable)","default_value":60,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog.plugins.beats.BeatsInput":{"type":"org.graylog.plugins.beats.BeatsInput","name":"Beats","requested_configuration":{"bind_address":{"human_name":"Bind
+        address","additional_info":{},"description":"Address to listen on. For example
+        0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5044,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.kafka.SyslogKafkaInput":{"type":"org.graylog2.inputs.syslog.kafka.SyslogKafkaInput","name":"Syslog
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.amqp.RawAMQPInput":{"type":"org.graylog2.inputs.raw.amqp.RawAMQPInput","name":"Raw/Plaintext
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.amqp.GELFAMQPInput":{"type":"org.graylog2.inputs.gelf.amqp.GELFAMQPInput","name":"GELF
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.kafka.RawKafkaInput":{"type":"org.graylog2.inputs.raw.kafka.RawKafkaInput","name":"Raw/Plaintext
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false}}'
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 19:49:31 GMT
+- request:
+    method: post
+    uri: http://localhost:9000/api/system/inputs
+    body:
+      encoding: UTF-8
+      string: '{"title":"Test_create_input","global":true,"configuration":{"bind_address":"0.0.0.0","port":5014},"type":"org.graylog2.inputs.syslog.udp.SyslogUDPInput"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Location:
+      - http://10.211.55.59:9000/api/system/inputs/59a3224b6aa21c18ab3f598c
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '3386'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 27 Aug 2017 19:49:31 GMT
+      Content-Length:
+      - '33'
+    body:
+      encoding: UTF-8
+      string: '{"id":"59a3224b6aa21c18ab3f598c"}'
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 19:49:31 GMT
+- request:
+    method: delete
+    uri: http://localhost:9000/api/system/inputs/59a3224b6aa21c18ab3f598c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '924'
+      Date:
+      - Sun, 27 Aug 2017 19:49:31 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 19:49:31 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/GraylogAPI_System_Inputs/create_input_with_type_name_insted_of_type/return_id.yml
+++ b/spec/fixtures/vcr/GraylogAPI_System_Inputs/create_input_with_type_name_insted_of_type/return_id.yml
@@ -1,0 +1,485 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9000/api/system/inputs/types/all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '1019'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 27 Aug 2017 19:49:31 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"org.graylog2.inputs.gelf.udp.GELFUDPInput":{"type":"org.graylog2.inputs.gelf.udp.GELFUDPInput","name":"GELF
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.amqp.SyslogAMQPInput":{"type":"org.graylog2.inputs.syslog.amqp.SyslogAMQPInput","name":"Syslog
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.kafka.GELFKafkaInput":{"type":"org.graylog2.inputs.gelf.kafka.GELFKafkaInput","name":"GELF
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.udp.SyslogUDPInput":{"type":"org.graylog2.inputs.syslog.udp.SyslogUDPInput","name":"Syslog
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.tcp.SyslogTCPInput":{"type":"org.graylog2.inputs.syslog.tcp.SyslogTCPInput","name":"Syslog
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.misc.jsonpath.JsonPathInput":{"type":"org.graylog2.inputs.misc.jsonpath.JsonPathInput","name":"JSON
+        path from HTTP API","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"target_url":{"human_name":"URI
+        of JSON resource","additional_info":{},"description":"HTTP resource returning
+        JSON on GET","default_value":"http://example.org/api","attributes":[],"type":"text","is_optional":false},"headers":{"human_name":"Additional
+        HTTP headers","additional_info":{},"description":"Add a comma separated list
+        of additional HTTP headers. For example: Accept: application/json, X-Requester:
+        Graylog","default_value":"","attributes":[],"type":"text","is_optional":true},"interval":{"human_name":"Interval","additional_info":{},"description":"Time
+        between every collector run. Select a time unit in the corresponding dropdown.
+        Example: Run every 5 minutes.","default_value":1,"attributes":[],"type":"number","is_optional":false},"timeunit":{"human_name":"Interval
+        time unit","additional_info":{"values":{"MILLISECONDS":"Milliseconds","MICROSECONDS":"Microseconds","HOURS":"Hours","SECONDS":"Seconds","NANOSECONDS":"Nanoseconds","DAYS":"Days","MINUTES":"Minutes"}},"description":null,"default_value":"MINUTES","attributes":[],"type":"dropdown","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"path":{"human_name":"JSON
+        path of data to extract","additional_info":{},"description":"Path to the value
+        you want to extract from the JSON response. Take a look at the documentation
+        for a more detailed explanation.","default_value":"$.store.book[1].number_of_orders","attributes":[],"type":"text","is_optional":false},"source":{"human_name":"Message
+        source","additional_info":{},"description":"What to use as source field of
+        the resulting message.","default_value":"yourapi","attributes":[],"type":"text","is_optional":false}},"link_to_docs":"http://docs.graylog.org/en/2.2/pages/sending_data.html#json-path-from-http-api-input","is_exclusive":false},"org.graylog2.inputs.raw.tcp.RawTCPInput":{"type":"org.graylog2.inputs.raw.tcp.RawTCPInput","name":"Raw/Plaintext
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5555,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.tcp.GELFTCPInput":{"type":"org.graylog2.inputs.gelf.tcp.GELFTCPInput","name":"GELF
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.udp.RawUDPInput":{"type":"org.graylog2.inputs.raw.udp.RawUDPInput","name":"Raw/Plaintext
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5555,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.random.FakeHttpMessageInput":{"type":"org.graylog2.inputs.random.FakeHttpMessageInput","name":"Random
+        HTTP message generator","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"sleep":{"human_name":"Sleep
+        time","additional_info":{},"description":"How many milliseconds to sleep between
+        generating messages.","default_value":25,"attributes":["only_positive"],"type":"number","is_optional":false},"sleep_deviation":{"human_name":"Maximum
+        random sleep time deviation","additional_info":{},"description":"The deviation
+        is used to generate a more realistic and non-steady message flow.","default_value":30,"attributes":["only_positive"],"type":"number","is_optional":false},"source":{"human_name":"Source
+        name","additional_info":{},"description":"What to use as source of the generate
+        messages.","default_value":"example.org","attributes":[],"type":"text","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.http.GELFHttpInput":{"type":"org.graylog2.inputs.gelf.http.GELFHttpInput","name":"GELF
+        HTTP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"enable_cors":{"human_name":"Enable
+        CORS","additional_info":{},"description":"Input sends CORS headers to satisfy
+        browser security policies","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"max_chunk_size":{"human_name":"Max.
+        HTTP chunk size","additional_info":{},"description":"The maximum HTTP chunk
+        size in bytes (e. g. length of HTTP request body)","default_value":65536,"attributes":[],"type":"number","is_optional":true},"idle_writer_timeout":{"human_name":"Idle
+        writer timeout","additional_info":{},"description":"The server closes the
+        connection after the given time in seconds after the last client write request.
+        (use 0 to disable)","default_value":60,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog.plugins.beats.BeatsInput":{"type":"org.graylog.plugins.beats.BeatsInput","name":"Beats","requested_configuration":{"bind_address":{"human_name":"Bind
+        address","additional_info":{},"description":"Address to listen on. For example
+        0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5044,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.kafka.SyslogKafkaInput":{"type":"org.graylog2.inputs.syslog.kafka.SyslogKafkaInput","name":"Syslog
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.amqp.RawAMQPInput":{"type":"org.graylog2.inputs.raw.amqp.RawAMQPInput","name":"Raw/Plaintext
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.amqp.GELFAMQPInput":{"type":"org.graylog2.inputs.gelf.amqp.GELFAMQPInput","name":"GELF
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.kafka.RawKafkaInput":{"type":"org.graylog2.inputs.raw.kafka.RawKafkaInput","name":"Raw/Plaintext
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false}}'
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 19:49:31 GMT
+- request:
+    method: post
+    uri: http://localhost:9000/api/system/inputs
+    body:
+      encoding: UTF-8
+      string: '{"title":"Test_create_input","global":true,"configuration":{"bind_address":"0.0.0.0","port":5014},"type":"org.graylog2.inputs.syslog.udp.SyslogUDPInput"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Location:
+      - http://10.211.55.59:9000/api/system/inputs/59a3224b6aa21c18ab3f598f
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '2927'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 27 Aug 2017 19:49:31 GMT
+      Content-Length:
+      - '33'
+    body:
+      encoding: UTF-8
+      string: '{"id":"59a3224b6aa21c18ab3f598f"}'
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 19:49:31 GMT
+- request:
+    method: delete
+    uri: http://localhost:9000/api/system/inputs/59a3224b6aa21c18ab3f598f
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '1224'
+      Date:
+      - Sun, 27 Aug 2017 19:49:31 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 19:49:31 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/GraylogAPI_System_Inputs/update_input_with_type_name_instead_of_type/code_201.yml
+++ b/spec/fixtures/vcr/GraylogAPI_System_Inputs/update_input_with_type_name_instead_of_type/code_201.yml
@@ -1,0 +1,524 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9000/api/system/inputs/types/all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '922'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 27 Aug 2017 20:26:04 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"org.graylog2.inputs.gelf.udp.GELFUDPInput":{"type":"org.graylog2.inputs.gelf.udp.GELFUDPInput","name":"GELF
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.amqp.SyslogAMQPInput":{"type":"org.graylog2.inputs.syslog.amqp.SyslogAMQPInput","name":"Syslog
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.kafka.GELFKafkaInput":{"type":"org.graylog2.inputs.gelf.kafka.GELFKafkaInput","name":"GELF
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.udp.SyslogUDPInput":{"type":"org.graylog2.inputs.syslog.udp.SyslogUDPInput","name":"Syslog
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.tcp.SyslogTCPInput":{"type":"org.graylog2.inputs.syslog.tcp.SyslogTCPInput","name":"Syslog
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.misc.jsonpath.JsonPathInput":{"type":"org.graylog2.inputs.misc.jsonpath.JsonPathInput","name":"JSON
+        path from HTTP API","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"target_url":{"human_name":"URI
+        of JSON resource","additional_info":{},"description":"HTTP resource returning
+        JSON on GET","default_value":"http://example.org/api","attributes":[],"type":"text","is_optional":false},"headers":{"human_name":"Additional
+        HTTP headers","additional_info":{},"description":"Add a comma separated list
+        of additional HTTP headers. For example: Accept: application/json, X-Requester:
+        Graylog","default_value":"","attributes":[],"type":"text","is_optional":true},"interval":{"human_name":"Interval","additional_info":{},"description":"Time
+        between every collector run. Select a time unit in the corresponding dropdown.
+        Example: Run every 5 minutes.","default_value":1,"attributes":[],"type":"number","is_optional":false},"timeunit":{"human_name":"Interval
+        time unit","additional_info":{"values":{"MILLISECONDS":"Milliseconds","MICROSECONDS":"Microseconds","HOURS":"Hours","SECONDS":"Seconds","NANOSECONDS":"Nanoseconds","DAYS":"Days","MINUTES":"Minutes"}},"description":null,"default_value":"MINUTES","attributes":[],"type":"dropdown","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"path":{"human_name":"JSON
+        path of data to extract","additional_info":{},"description":"Path to the value
+        you want to extract from the JSON response. Take a look at the documentation
+        for a more detailed explanation.","default_value":"$.store.book[1].number_of_orders","attributes":[],"type":"text","is_optional":false},"source":{"human_name":"Message
+        source","additional_info":{},"description":"What to use as source field of
+        the resulting message.","default_value":"yourapi","attributes":[],"type":"text","is_optional":false}},"link_to_docs":"http://docs.graylog.org/en/2.2/pages/sending_data.html#json-path-from-http-api-input","is_exclusive":false},"org.graylog2.inputs.raw.tcp.RawTCPInput":{"type":"org.graylog2.inputs.raw.tcp.RawTCPInput","name":"Raw/Plaintext
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5555,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.tcp.GELFTCPInput":{"type":"org.graylog2.inputs.gelf.tcp.GELFTCPInput","name":"GELF
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.udp.RawUDPInput":{"type":"org.graylog2.inputs.raw.udp.RawUDPInput","name":"Raw/Plaintext
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5555,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.random.FakeHttpMessageInput":{"type":"org.graylog2.inputs.random.FakeHttpMessageInput","name":"Random
+        HTTP message generator","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"sleep":{"human_name":"Sleep
+        time","additional_info":{},"description":"How many milliseconds to sleep between
+        generating messages.","default_value":25,"attributes":["only_positive"],"type":"number","is_optional":false},"sleep_deviation":{"human_name":"Maximum
+        random sleep time deviation","additional_info":{},"description":"The deviation
+        is used to generate a more realistic and non-steady message flow.","default_value":30,"attributes":["only_positive"],"type":"number","is_optional":false},"source":{"human_name":"Source
+        name","additional_info":{},"description":"What to use as source of the generate
+        messages.","default_value":"example.org","attributes":[],"type":"text","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.http.GELFHttpInput":{"type":"org.graylog2.inputs.gelf.http.GELFHttpInput","name":"GELF
+        HTTP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"enable_cors":{"human_name":"Enable
+        CORS","additional_info":{},"description":"Input sends CORS headers to satisfy
+        browser security policies","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"max_chunk_size":{"human_name":"Max.
+        HTTP chunk size","additional_info":{},"description":"The maximum HTTP chunk
+        size in bytes (e. g. length of HTTP request body)","default_value":65536,"attributes":[],"type":"number","is_optional":true},"idle_writer_timeout":{"human_name":"Idle
+        writer timeout","additional_info":{},"description":"The server closes the
+        connection after the given time in seconds after the last client write request.
+        (use 0 to disable)","default_value":60,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog.plugins.beats.BeatsInput":{"type":"org.graylog.plugins.beats.BeatsInput","name":"Beats","requested_configuration":{"bind_address":{"human_name":"Bind
+        address","additional_info":{},"description":"Address to listen on. For example
+        0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5044,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.kafka.SyslogKafkaInput":{"type":"org.graylog2.inputs.syslog.kafka.SyslogKafkaInput","name":"Syslog
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.amqp.RawAMQPInput":{"type":"org.graylog2.inputs.raw.amqp.RawAMQPInput","name":"Raw/Plaintext
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.amqp.GELFAMQPInput":{"type":"org.graylog2.inputs.gelf.amqp.GELFAMQPInput","name":"GELF
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.kafka.RawKafkaInput":{"type":"org.graylog2.inputs.raw.kafka.RawKafkaInput","name":"Raw/Plaintext
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false}}'
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 20:26:05 GMT
+- request:
+    method: post
+    uri: http://localhost:9000/api/system/inputs
+    body:
+      encoding: UTF-8
+      string: '{"title":"Update_input","global":true,"configuration":{"bind_address":"0.0.0.0","port":5044},"type":"org.graylog.plugins.beats.BeatsInput"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Location:
+      - http://10.211.55.59:9000/api/system/inputs/59a32add6aa21c18ab3f6292
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '2205'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 27 Aug 2017 20:26:04 GMT
+      Content-Length:
+      - '33'
+    body:
+      encoding: UTF-8
+      string: '{"id":"59a32add6aa21c18ab3f6292"}'
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 20:26:05 GMT
+- request:
+    method: put
+    uri: http://localhost:9000/api/system/inputs/59a32add6aa21c18ab3f6292
+    body:
+      encoding: UTF-8
+      string: '{"title":"Update_input","global":true,"configuration":{"bind_address":"0.0.0.0","port":5044},"type":"org.graylog.plugins.beats.BeatsInput"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Location:
+      - http://10.211.55.59:9000/api/system/inputs/59a32add6aa21c18ab3f6292
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '3268'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 27 Aug 2017 20:26:04 GMT
+      Content-Length:
+      - '33'
+    body:
+      encoding: UTF-8
+      string: '{"id":"59a32add6aa21c18ab3f6292"}'
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 20:26:05 GMT
+- request:
+    method: delete
+    uri: http://localhost:9000/api/system/inputs/59a32add6aa21c18ab3f6292
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '1009'
+      Date:
+      - Sun, 27 Aug 2017 20:26:04 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 20:26:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/GraylogAPI_System_Inputs/update_input_with_type_name_instead_of_type/return_id.yml
+++ b/spec/fixtures/vcr/GraylogAPI_System_Inputs/update_input_with_type_name_instead_of_type/return_id.yml
@@ -1,0 +1,524 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9000/api/system/inputs/types/all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '1149'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 27 Aug 2017 20:26:04 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"org.graylog2.inputs.gelf.udp.GELFUDPInput":{"type":"org.graylog2.inputs.gelf.udp.GELFUDPInput","name":"GELF
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.amqp.SyslogAMQPInput":{"type":"org.graylog2.inputs.syslog.amqp.SyslogAMQPInput","name":"Syslog
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.kafka.GELFKafkaInput":{"type":"org.graylog2.inputs.gelf.kafka.GELFKafkaInput","name":"GELF
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.udp.SyslogUDPInput":{"type":"org.graylog2.inputs.syslog.udp.SyslogUDPInput","name":"Syslog
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.tcp.SyslogTCPInput":{"type":"org.graylog2.inputs.syslog.tcp.SyslogTCPInput","name":"Syslog
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.misc.jsonpath.JsonPathInput":{"type":"org.graylog2.inputs.misc.jsonpath.JsonPathInput","name":"JSON
+        path from HTTP API","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"target_url":{"human_name":"URI
+        of JSON resource","additional_info":{},"description":"HTTP resource returning
+        JSON on GET","default_value":"http://example.org/api","attributes":[],"type":"text","is_optional":false},"headers":{"human_name":"Additional
+        HTTP headers","additional_info":{},"description":"Add a comma separated list
+        of additional HTTP headers. For example: Accept: application/json, X-Requester:
+        Graylog","default_value":"","attributes":[],"type":"text","is_optional":true},"interval":{"human_name":"Interval","additional_info":{},"description":"Time
+        between every collector run. Select a time unit in the corresponding dropdown.
+        Example: Run every 5 minutes.","default_value":1,"attributes":[],"type":"number","is_optional":false},"timeunit":{"human_name":"Interval
+        time unit","additional_info":{"values":{"MILLISECONDS":"Milliseconds","MICROSECONDS":"Microseconds","HOURS":"Hours","SECONDS":"Seconds","NANOSECONDS":"Nanoseconds","DAYS":"Days","MINUTES":"Minutes"}},"description":null,"default_value":"MINUTES","attributes":[],"type":"dropdown","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"path":{"human_name":"JSON
+        path of data to extract","additional_info":{},"description":"Path to the value
+        you want to extract from the JSON response. Take a look at the documentation
+        for a more detailed explanation.","default_value":"$.store.book[1].number_of_orders","attributes":[],"type":"text","is_optional":false},"source":{"human_name":"Message
+        source","additional_info":{},"description":"What to use as source field of
+        the resulting message.","default_value":"yourapi","attributes":[],"type":"text","is_optional":false}},"link_to_docs":"http://docs.graylog.org/en/2.2/pages/sending_data.html#json-path-from-http-api-input","is_exclusive":false},"org.graylog2.inputs.raw.tcp.RawTCPInput":{"type":"org.graylog2.inputs.raw.tcp.RawTCPInput","name":"Raw/Plaintext
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5555,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.tcp.GELFTCPInput":{"type":"org.graylog2.inputs.gelf.tcp.GELFTCPInput","name":"GELF
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.udp.RawUDPInput":{"type":"org.graylog2.inputs.raw.udp.RawUDPInput","name":"Raw/Plaintext
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5555,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.random.FakeHttpMessageInput":{"type":"org.graylog2.inputs.random.FakeHttpMessageInput","name":"Random
+        HTTP message generator","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"sleep":{"human_name":"Sleep
+        time","additional_info":{},"description":"How many milliseconds to sleep between
+        generating messages.","default_value":25,"attributes":["only_positive"],"type":"number","is_optional":false},"sleep_deviation":{"human_name":"Maximum
+        random sleep time deviation","additional_info":{},"description":"The deviation
+        is used to generate a more realistic and non-steady message flow.","default_value":30,"attributes":["only_positive"],"type":"number","is_optional":false},"source":{"human_name":"Source
+        name","additional_info":{},"description":"What to use as source of the generate
+        messages.","default_value":"example.org","attributes":[],"type":"text","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.http.GELFHttpInput":{"type":"org.graylog2.inputs.gelf.http.GELFHttpInput","name":"GELF
+        HTTP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"enable_cors":{"human_name":"Enable
+        CORS","additional_info":{},"description":"Input sends CORS headers to satisfy
+        browser security policies","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"max_chunk_size":{"human_name":"Max.
+        HTTP chunk size","additional_info":{},"description":"The maximum HTTP chunk
+        size in bytes (e. g. length of HTTP request body)","default_value":65536,"attributes":[],"type":"number","is_optional":true},"idle_writer_timeout":{"human_name":"Idle
+        writer timeout","additional_info":{},"description":"The server closes the
+        connection after the given time in seconds after the last client write request.
+        (use 0 to disable)","default_value":60,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog.plugins.beats.BeatsInput":{"type":"org.graylog.plugins.beats.BeatsInput","name":"Beats","requested_configuration":{"bind_address":{"human_name":"Bind
+        address","additional_info":{},"description":"Address to listen on. For example
+        0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5044,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.kafka.SyslogKafkaInput":{"type":"org.graylog2.inputs.syslog.kafka.SyslogKafkaInput","name":"Syslog
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.amqp.RawAMQPInput":{"type":"org.graylog2.inputs.raw.amqp.RawAMQPInput","name":"Raw/Plaintext
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.amqp.GELFAMQPInput":{"type":"org.graylog2.inputs.gelf.amqp.GELFAMQPInput","name":"GELF
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.kafka.RawKafkaInput":{"type":"org.graylog2.inputs.raw.kafka.RawKafkaInput","name":"Raw/Plaintext
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false}}'
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 20:26:05 GMT
+- request:
+    method: post
+    uri: http://localhost:9000/api/system/inputs
+    body:
+      encoding: UTF-8
+      string: '{"title":"Update_input","global":true,"configuration":{"bind_address":"0.0.0.0","port":5044},"type":"org.graylog.plugins.beats.BeatsInput"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Location:
+      - http://10.211.55.59:9000/api/system/inputs/59a32add6aa21c18ab3f6296
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '5068'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 27 Aug 2017 20:26:04 GMT
+      Content-Length:
+      - '33'
+    body:
+      encoding: UTF-8
+      string: '{"id":"59a32add6aa21c18ab3f6296"}'
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 20:26:05 GMT
+- request:
+    method: put
+    uri: http://localhost:9000/api/system/inputs/59a32add6aa21c18ab3f6296
+    body:
+      encoding: UTF-8
+      string: '{"title":"Update_input","global":true,"configuration":{"bind_address":"0.0.0.0","port":5044},"type":"org.graylog.plugins.beats.BeatsInput"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Location:
+      - http://10.211.55.59:9000/api/system/inputs/59a32add6aa21c18ab3f6296
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '2447'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 27 Aug 2017 20:26:04 GMT
+      Content-Length:
+      - '33'
+    body:
+      encoding: UTF-8
+      string: '{"id":"59a32add6aa21c18ab3f6296"}'
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 20:26:05 GMT
+- request:
+    method: delete
+    uri: http://localhost:9000/api/system/inputs/59a32add6aa21c18ab3f6296
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '838'
+      Date:
+      - Sun, 27 Aug 2017 20:26:04 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 20:26:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/all/code_200.yml
+++ b/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/all/code_200.yml
@@ -1,0 +1,413 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9000/api/system/inputs/types/all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '1363'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 27 Aug 2017 18:41:46 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"org.graylog2.inputs.gelf.udp.GELFUDPInput":{"type":"org.graylog2.inputs.gelf.udp.GELFUDPInput","name":"GELF
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.amqp.SyslogAMQPInput":{"type":"org.graylog2.inputs.syslog.amqp.SyslogAMQPInput","name":"Syslog
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.kafka.GELFKafkaInput":{"type":"org.graylog2.inputs.gelf.kafka.GELFKafkaInput","name":"GELF
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.udp.SyslogUDPInput":{"type":"org.graylog2.inputs.syslog.udp.SyslogUDPInput","name":"Syslog
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.tcp.SyslogTCPInput":{"type":"org.graylog2.inputs.syslog.tcp.SyslogTCPInput","name":"Syslog
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.misc.jsonpath.JsonPathInput":{"type":"org.graylog2.inputs.misc.jsonpath.JsonPathInput","name":"JSON
+        path from HTTP API","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"target_url":{"human_name":"URI
+        of JSON resource","additional_info":{},"description":"HTTP resource returning
+        JSON on GET","default_value":"http://example.org/api","attributes":[],"type":"text","is_optional":false},"headers":{"human_name":"Additional
+        HTTP headers","additional_info":{},"description":"Add a comma separated list
+        of additional HTTP headers. For example: Accept: application/json, X-Requester:
+        Graylog","default_value":"","attributes":[],"type":"text","is_optional":true},"interval":{"human_name":"Interval","additional_info":{},"description":"Time
+        between every collector run. Select a time unit in the corresponding dropdown.
+        Example: Run every 5 minutes.","default_value":1,"attributes":[],"type":"number","is_optional":false},"timeunit":{"human_name":"Interval
+        time unit","additional_info":{"values":{"MILLISECONDS":"Milliseconds","MICROSECONDS":"Microseconds","HOURS":"Hours","SECONDS":"Seconds","NANOSECONDS":"Nanoseconds","DAYS":"Days","MINUTES":"Minutes"}},"description":null,"default_value":"MINUTES","attributes":[],"type":"dropdown","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"path":{"human_name":"JSON
+        path of data to extract","additional_info":{},"description":"Path to the value
+        you want to extract from the JSON response. Take a look at the documentation
+        for a more detailed explanation.","default_value":"$.store.book[1].number_of_orders","attributes":[],"type":"text","is_optional":false},"source":{"human_name":"Message
+        source","additional_info":{},"description":"What to use as source field of
+        the resulting message.","default_value":"yourapi","attributes":[],"type":"text","is_optional":false}},"link_to_docs":"http://docs.graylog.org/en/2.2/pages/sending_data.html#json-path-from-http-api-input","is_exclusive":false},"org.graylog2.inputs.raw.tcp.RawTCPInput":{"type":"org.graylog2.inputs.raw.tcp.RawTCPInput","name":"Raw/Plaintext
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5555,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.tcp.GELFTCPInput":{"type":"org.graylog2.inputs.gelf.tcp.GELFTCPInput","name":"GELF
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.udp.RawUDPInput":{"type":"org.graylog2.inputs.raw.udp.RawUDPInput","name":"Raw/Plaintext
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5555,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.random.FakeHttpMessageInput":{"type":"org.graylog2.inputs.random.FakeHttpMessageInput","name":"Random
+        HTTP message generator","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"sleep":{"human_name":"Sleep
+        time","additional_info":{},"description":"How many milliseconds to sleep between
+        generating messages.","default_value":25,"attributes":["only_positive"],"type":"number","is_optional":false},"sleep_deviation":{"human_name":"Maximum
+        random sleep time deviation","additional_info":{},"description":"The deviation
+        is used to generate a more realistic and non-steady message flow.","default_value":30,"attributes":["only_positive"],"type":"number","is_optional":false},"source":{"human_name":"Source
+        name","additional_info":{},"description":"What to use as source of the generate
+        messages.","default_value":"example.org","attributes":[],"type":"text","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.http.GELFHttpInput":{"type":"org.graylog2.inputs.gelf.http.GELFHttpInput","name":"GELF
+        HTTP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"enable_cors":{"human_name":"Enable
+        CORS","additional_info":{},"description":"Input sends CORS headers to satisfy
+        browser security policies","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"max_chunk_size":{"human_name":"Max.
+        HTTP chunk size","additional_info":{},"description":"The maximum HTTP chunk
+        size in bytes (e. g. length of HTTP request body)","default_value":65536,"attributes":[],"type":"number","is_optional":true},"idle_writer_timeout":{"human_name":"Idle
+        writer timeout","additional_info":{},"description":"The server closes the
+        connection after the given time in seconds after the last client write request.
+        (use 0 to disable)","default_value":60,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog.plugins.beats.BeatsInput":{"type":"org.graylog.plugins.beats.BeatsInput","name":"Beats","requested_configuration":{"bind_address":{"human_name":"Bind
+        address","additional_info":{},"description":"Address to listen on. For example
+        0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5044,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.kafka.SyslogKafkaInput":{"type":"org.graylog2.inputs.syslog.kafka.SyslogKafkaInput","name":"Syslog
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.amqp.RawAMQPInput":{"type":"org.graylog2.inputs.raw.amqp.RawAMQPInput","name":"Raw/Plaintext
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.amqp.GELFAMQPInput":{"type":"org.graylog2.inputs.gelf.amqp.GELFAMQPInput","name":"GELF
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.kafka.RawKafkaInput":{"type":"org.graylog2.inputs.raw.kafka.RawKafkaInput","name":"Raw/Plaintext
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false}}'
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 18:41:46 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/all/contain_types.yml
+++ b/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/all/contain_types.yml
@@ -1,0 +1,413 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9000/api/system/inputs/types/all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '1498'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 27 Aug 2017 18:41:46 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"org.graylog2.inputs.gelf.udp.GELFUDPInput":{"type":"org.graylog2.inputs.gelf.udp.GELFUDPInput","name":"GELF
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.amqp.SyslogAMQPInput":{"type":"org.graylog2.inputs.syslog.amqp.SyslogAMQPInput","name":"Syslog
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.kafka.GELFKafkaInput":{"type":"org.graylog2.inputs.gelf.kafka.GELFKafkaInput","name":"GELF
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.udp.SyslogUDPInput":{"type":"org.graylog2.inputs.syslog.udp.SyslogUDPInput","name":"Syslog
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.tcp.SyslogTCPInput":{"type":"org.graylog2.inputs.syslog.tcp.SyslogTCPInput","name":"Syslog
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.misc.jsonpath.JsonPathInput":{"type":"org.graylog2.inputs.misc.jsonpath.JsonPathInput","name":"JSON
+        path from HTTP API","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"target_url":{"human_name":"URI
+        of JSON resource","additional_info":{},"description":"HTTP resource returning
+        JSON on GET","default_value":"http://example.org/api","attributes":[],"type":"text","is_optional":false},"headers":{"human_name":"Additional
+        HTTP headers","additional_info":{},"description":"Add a comma separated list
+        of additional HTTP headers. For example: Accept: application/json, X-Requester:
+        Graylog","default_value":"","attributes":[],"type":"text","is_optional":true},"interval":{"human_name":"Interval","additional_info":{},"description":"Time
+        between every collector run. Select a time unit in the corresponding dropdown.
+        Example: Run every 5 minutes.","default_value":1,"attributes":[],"type":"number","is_optional":false},"timeunit":{"human_name":"Interval
+        time unit","additional_info":{"values":{"MILLISECONDS":"Milliseconds","MICROSECONDS":"Microseconds","HOURS":"Hours","SECONDS":"Seconds","NANOSECONDS":"Nanoseconds","DAYS":"Days","MINUTES":"Minutes"}},"description":null,"default_value":"MINUTES","attributes":[],"type":"dropdown","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"path":{"human_name":"JSON
+        path of data to extract","additional_info":{},"description":"Path to the value
+        you want to extract from the JSON response. Take a look at the documentation
+        for a more detailed explanation.","default_value":"$.store.book[1].number_of_orders","attributes":[],"type":"text","is_optional":false},"source":{"human_name":"Message
+        source","additional_info":{},"description":"What to use as source field of
+        the resulting message.","default_value":"yourapi","attributes":[],"type":"text","is_optional":false}},"link_to_docs":"http://docs.graylog.org/en/2.2/pages/sending_data.html#json-path-from-http-api-input","is_exclusive":false},"org.graylog2.inputs.raw.tcp.RawTCPInput":{"type":"org.graylog2.inputs.raw.tcp.RawTCPInput","name":"Raw/Plaintext
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5555,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.tcp.GELFTCPInput":{"type":"org.graylog2.inputs.gelf.tcp.GELFTCPInput","name":"GELF
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.udp.RawUDPInput":{"type":"org.graylog2.inputs.raw.udp.RawUDPInput","name":"Raw/Plaintext
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5555,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.random.FakeHttpMessageInput":{"type":"org.graylog2.inputs.random.FakeHttpMessageInput","name":"Random
+        HTTP message generator","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"sleep":{"human_name":"Sleep
+        time","additional_info":{},"description":"How many milliseconds to sleep between
+        generating messages.","default_value":25,"attributes":["only_positive"],"type":"number","is_optional":false},"sleep_deviation":{"human_name":"Maximum
+        random sleep time deviation","additional_info":{},"description":"The deviation
+        is used to generate a more realistic and non-steady message flow.","default_value":30,"attributes":["only_positive"],"type":"number","is_optional":false},"source":{"human_name":"Source
+        name","additional_info":{},"description":"What to use as source of the generate
+        messages.","default_value":"example.org","attributes":[],"type":"text","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.http.GELFHttpInput":{"type":"org.graylog2.inputs.gelf.http.GELFHttpInput","name":"GELF
+        HTTP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"enable_cors":{"human_name":"Enable
+        CORS","additional_info":{},"description":"Input sends CORS headers to satisfy
+        browser security policies","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"max_chunk_size":{"human_name":"Max.
+        HTTP chunk size","additional_info":{},"description":"The maximum HTTP chunk
+        size in bytes (e. g. length of HTTP request body)","default_value":65536,"attributes":[],"type":"number","is_optional":true},"idle_writer_timeout":{"human_name":"Idle
+        writer timeout","additional_info":{},"description":"The server closes the
+        connection after the given time in seconds after the last client write request.
+        (use 0 to disable)","default_value":60,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog.plugins.beats.BeatsInput":{"type":"org.graylog.plugins.beats.BeatsInput","name":"Beats","requested_configuration":{"bind_address":{"human_name":"Bind
+        address","additional_info":{},"description":"Address to listen on. For example
+        0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5044,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.kafka.SyslogKafkaInput":{"type":"org.graylog2.inputs.syslog.kafka.SyslogKafkaInput","name":"Syslog
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.amqp.RawAMQPInput":{"type":"org.graylog2.inputs.raw.amqp.RawAMQPInput","name":"Raw/Plaintext
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.amqp.GELFAMQPInput":{"type":"org.graylog2.inputs.gelf.amqp.GELFAMQPInput","name":"GELF
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.kafka.RawKafkaInput":{"type":"org.graylog2.inputs.raw.kafka.RawKafkaInput","name":"Raw/Plaintext
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false}}'
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 18:41:46 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/get_by_inputType/code_200.yml
+++ b/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/get_by_inputType/code_200.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9000/api/system/inputs/types/org.graylog2.inputs.syslog.udp.SyslogUDPInput
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '825'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 27 Aug 2017 18:42:46 GMT
+      Content-Length:
+      - '2107'
+    body:
+      encoding: UTF-8
+      string: '{"type":"org.graylog2.inputs.syslog.udp.SyslogUDPInput","name":"Syslog
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false}'
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 18:42:47 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/get_by_inputType/contain_name.yml
+++ b/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/get_by_inputType/contain_name.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9000/api/system/inputs/types/org.graylog2.inputs.syslog.udp.SyslogUDPInput
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '778'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 27 Aug 2017 18:42:46 GMT
+      Content-Length:
+      - '2107'
+    body:
+      encoding: UTF-8
+      string: '{"type":"org.graylog2.inputs.syslog.udp.SyslogUDPInput","name":"Syslog
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false}'
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 18:42:47 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/get_by_inputType/contain_type.yml
+++ b/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/get_by_inputType/contain_type.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9000/api/system/inputs/types/org.graylog2.inputs.syslog.udp.SyslogUDPInput
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '797'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 27 Aug 2017 18:42:46 GMT
+      Content-Length:
+      - '2107'
+    body:
+      encoding: UTF-8
+      string: '{"type":"org.graylog2.inputs.syslog.udp.SyslogUDPInput","name":"Syslog
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false}'
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 18:42:47 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/node/code_200.yml
+++ b/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/node/code_200.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9000/api/system/inputs/types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '949'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 27 Aug 2017 18:41:20 GMT
+      Content-Length:
+      - '1013'
+    body:
+      encoding: UTF-8
+      string: '{"types":{"org.graylog2.inputs.gelf.udp.GELFUDPInput":"GELF UDP","org.graylog2.inputs.syslog.amqp.SyslogAMQPInput":"Syslog
+        AMQP","org.graylog2.inputs.gelf.kafka.GELFKafkaInput":"GELF Kafka","org.graylog2.inputs.syslog.udp.SyslogUDPInput":"Syslog
+        UDP","org.graylog2.inputs.syslog.tcp.SyslogTCPInput":"Syslog TCP","org.graylog2.inputs.misc.jsonpath.JsonPathInput":"JSON
+        path from HTTP API","org.graylog2.inputs.raw.tcp.RawTCPInput":"Raw/Plaintext
+        TCP","org.graylog2.inputs.raw.udp.RawUDPInput":"Raw/Plaintext UDP","org.graylog2.inputs.gelf.tcp.GELFTCPInput":"GELF
+        TCP","org.graylog2.inputs.random.FakeHttpMessageInput":"Random HTTP message
+        generator","org.graylog2.inputs.gelf.http.GELFHttpInput":"GELF HTTP","org.graylog2.inputs.syslog.kafka.SyslogKafkaInput":"Syslog
+        Kafka","org.graylog.plugins.beats.BeatsInput":"Beats","org.graylog2.inputs.raw.amqp.RawAMQPInput":"Raw/Plaintext
+        AMQP","org.graylog2.inputs.raw.kafka.RawKafkaInput":"Raw/Plaintext Kafka","org.graylog2.inputs.gelf.amqp.GELFAMQPInput":"GELF
+        AMQP"}}'
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 18:41:20 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/node/contain_types.yml
+++ b/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/node/contain_types.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9000/api/system/inputs/types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Graylog-Node-Id:
+      - ad9b9139-c1eb-4eca-8e14-5c2fdf2ddfd7
+      X-Runtime-Microseconds:
+      - '1151'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 27 Aug 2017 18:41:20 GMT
+      Content-Length:
+      - '1013'
+    body:
+      encoding: UTF-8
+      string: '{"types":{"org.graylog2.inputs.gelf.udp.GELFUDPInput":"GELF UDP","org.graylog2.inputs.syslog.amqp.SyslogAMQPInput":"Syslog
+        AMQP","org.graylog2.inputs.gelf.kafka.GELFKafkaInput":"GELF Kafka","org.graylog2.inputs.syslog.udp.SyslogUDPInput":"Syslog
+        UDP","org.graylog2.inputs.syslog.tcp.SyslogTCPInput":"Syslog TCP","org.graylog2.inputs.misc.jsonpath.JsonPathInput":"JSON
+        path from HTTP API","org.graylog2.inputs.raw.tcp.RawTCPInput":"Raw/Plaintext
+        TCP","org.graylog2.inputs.raw.udp.RawUDPInput":"Raw/Plaintext UDP","org.graylog2.inputs.gelf.tcp.GELFTCPInput":"GELF
+        TCP","org.graylog2.inputs.random.FakeHttpMessageInput":"Random HTTP message
+        generator","org.graylog2.inputs.gelf.http.GELFHttpInput":"GELF HTTP","org.graylog2.inputs.syslog.kafka.SyslogKafkaInput":"Syslog
+        Kafka","org.graylog.plugins.beats.BeatsInput":"Beats","org.graylog2.inputs.raw.amqp.RawAMQPInput":"Raw/Plaintext
+        AMQP","org.graylog2.inputs.raw.kafka.RawKafkaInput":"Raw/Plaintext Kafka","org.graylog2.inputs.gelf.amqp.GELFAMQPInput":"GELF
+        AMQP"}}'
+    http_version: 
+  recorded_at: Sun, 27 Aug 2017 18:41:20 GMT
+recorded_with: VCR 3.0.3

--- a/spec/graylog_api/system/cluster_spec.rb
+++ b/spec/graylog_api/system/cluster_spec.rb
@@ -1,4 +1,3 @@
-require 'pry'
 describe GraylogAPI::System::Cluster, vcr: true do
   include_context 'graylogapi'
 

--- a/spec/graylog_api/system/inputs/types_spec.rb
+++ b/spec/graylog_api/system/inputs/types_spec.rb
@@ -1,0 +1,52 @@
+describe GraylogAPI::System::Inputs::Types, vcr: true do
+  include_context 'graylogapi'
+
+  context 'node' do
+    subject(:response) do
+      graylogapi.system.inputs.types.node
+    end
+
+    it 'code 200' do
+      expect(response.code).to eq 200
+    end
+
+    it 'contain types' do
+      expect(response.keys).to include 'types'
+    end
+  end
+
+  context 'all' do
+    subject(:response) do
+      graylogapi.system.inputs.types.all
+    end
+
+    it 'code 200' do
+      expect(response.code).to eq 200
+    end
+
+    it 'contain types' do
+      expect(response.keys).to include 'org.graylog2.inputs.syslog.udp.SyslogUDPInput'
+    end
+  end
+
+  context 'get by inputType' do
+    subject(:response) do
+      graylogapi.system.inputs.types.by_type(type)
+    end
+
+    let(:type) { 'org.graylog2.inputs.syslog.udp.SyslogUDPInput' }
+    let(:name) { 'Syslog UDP' }
+
+    it 'code 200' do
+      expect(response.code).to eq 200
+    end
+
+    it 'contain type' do
+      expect(response['type']).to eq type
+    end
+
+    it 'contain name' do
+      expect(response['name']).to eq name
+    end
+  end
+end

--- a/spec/graylog_api/system/inputs_spec.rb
+++ b/spec/graylog_api/system/inputs_spec.rb
@@ -24,6 +24,27 @@ describe GraylogAPI::System::Inputs, vcr: true do
     end
   end
 
+  context 'create input with type name insted of type' do
+    subject(:response) do
+      options = { title: 'Test_create_input',
+                  type_name: 'Syslog UDP',
+                  global: true,
+                  configuration: { bind_address: '0.0.0.0',
+                                   port: 5014 } }
+      res = graylogapi.system.inputs.create(options)
+      graylogapi.system.inputs.delete(res['id'])
+      res
+    end
+
+    it 'code 201' do
+      expect(response.code).to eq 201
+    end
+
+    it 'return id' do
+      expect(response.keys).to contain_exactly 'id'
+    end
+  end
+
   context 'update input' do
     subject(:response) do
       options = { title: 'Input by gem123',
@@ -36,6 +57,28 @@ describe GraylogAPI::System::Inputs, vcr: true do
       req = graylogapi.system.inputs.update(input['id'], options)
       graylogapi.system.inputs.delete(input['id'])
       req
+    end
+
+    it 'code 201' do
+      expect(response.code).to eq 201
+    end
+
+    it 'return id' do
+      expect(response.keys).to contain_exactly 'id'
+    end
+  end
+
+  context 'update input with type name instead of type' do
+    subject(:response) do
+      options = { title: 'Update_input',
+                  type_name: 'Beats',
+                  global: true,
+                  configuration: { bind_address: '0.0.0.0',
+                                   port: 5044 } }
+      input = graylogapi.system.inputs.create(options)
+      res = graylogapi.system.inputs.update(input['id'], options)
+      graylogapi.system.inputs.delete(input['id'])
+      res
     end
 
     it 'code 201' do


### PR DESCRIPTION
* Add System/Inputs/Types
    * node - Get all available input types of this node
    * all - Get information about all input types
    * by_type - Get information about a single input type
    * name_to_type - Convert name of type to type

* Use name of type then create an input

Example:
```(ruby)
graylogapi.system.inputs.create(title: 'New input', type_name: 'Syslog UDP', ...)

# instead of

graylogapi.system.inputs.create(title: 'New input', type: 'org.graylog2.inputs.syslog.udp.SyslogUDPInput', ...)
```
