### PR TITLE
fix base_url with slash at the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Released
 
+## [1.2.1] - 2017-21-17
+
+### Fixed
+
+- `options[:base_url]` can be with slash at the end
+
 ## [1.2.0] - 2017-09-18
 
 ### Added

--- a/lib/graylogapi/client.rb
+++ b/lib/graylogapi/client.rb
@@ -27,6 +27,7 @@ class GraylogAPI
     # @return [GraylogAPI::Client]
     def initialize(options = {})
       @options = options
+      @options[:base_url] = options[:base_url].chomp('/')
       @http = http_client(URI.parse(options[:base_url]), options)
     end
 


### PR DESCRIPTION
Fix problem with slash at the end of the `options[:base_url]`.

Now both endpoints works: `http://localhost:9000` and `http://localhost:9000/`