### PR TITLE
Convert input type_id to input type name

### DIFF
--- a/lib/graylogapi/system/inputs/types.rb
+++ b/lib/graylogapi/system/inputs/types.rb
@@ -34,6 +34,13 @@ class GraylogAPI
         def name_to_type(name)
           all.body.find { |_, type| type['name'].casecmp(name).zero? }.first
         end
+
+        # converg type_id to type name
+        #
+        # @return [String]
+        def type_to_name(type_id)
+          all.body.find { |_, type| type['type'].casecmp(type_id).zero? }.last['name']
+        end
       end
     end
   end

--- a/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/converge_type_id_to_type_name/return_type_name.yml
+++ b/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/converge_type_id_to_type_name/return_type_name.yml
@@ -1,0 +1,425 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9000/api/system/inputs/types/all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Graylog-Node-Id:
+      - f400dd86-7ae8-4483-a100-659a1f0f3310
+      X-Runtime-Microseconds:
+      - '28646'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 11 Oct 2017 19:07:10 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"org.graylog2.inputs.gelf.udp.GELFUDPInput":{"type":"org.graylog2.inputs.gelf.udp.GELFUDPInput","name":"GELF
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.amqp.SyslogAMQPInput":{"type":"org.graylog2.inputs.syslog.amqp.SyslogAMQPInput","name":"Syslog
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.kafka.GELFKafkaInput":{"type":"org.graylog2.inputs.gelf.kafka.GELFKafkaInput","name":"GELF
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"offset_reset":{"human_name":"Auto
+        offset reset","additional_info":{"values":{"largest":"Automatically reset
+        the offset to the largest offset","smallest":"Automatically reset the offset
+        to the smallest offset"}},"description":"What to do when there is no initial
+        offset in ZooKeeper or if an offset is out of range","default_value":"largest","attributes":[],"type":"dropdown","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.udp.SyslogUDPInput":{"type":"org.graylog2.inputs.syslog.udp.SyslogUDPInput","name":"Syslog
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.tcp.SyslogTCPInput":{"type":"org.graylog2.inputs.syslog.tcp.SyslogTCPInput","name":"Syslog
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.misc.jsonpath.JsonPathInput":{"type":"org.graylog2.inputs.misc.jsonpath.JsonPathInput","name":"JSON
+        path from HTTP API","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"target_url":{"human_name":"URI
+        of JSON resource","additional_info":{},"description":"HTTP resource returning
+        JSON on GET","default_value":"http://example.org/api","attributes":[],"type":"text","is_optional":false},"headers":{"human_name":"Additional
+        HTTP headers","additional_info":{},"description":"Add a comma separated list
+        of additional HTTP headers. For example: Accept: application/json, X-Requester:
+        Graylog","default_value":"","attributes":[],"type":"text","is_optional":true},"interval":{"human_name":"Interval","additional_info":{},"description":"Time
+        between every collector run. Select a time unit in the corresponding dropdown.
+        Example: Run every 5 minutes.","default_value":1,"attributes":[],"type":"number","is_optional":false},"timeunit":{"human_name":"Interval
+        time unit","additional_info":{"values":{"MILLISECONDS":"Milliseconds","MICROSECONDS":"Microseconds","HOURS":"Hours","SECONDS":"Seconds","NANOSECONDS":"Nanoseconds","DAYS":"Days","MINUTES":"Minutes"}},"description":null,"default_value":"MINUTES","attributes":[],"type":"dropdown","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"path":{"human_name":"JSON
+        path of data to extract","additional_info":{},"description":"Path to the value
+        you want to extract from the JSON response. Take a look at the documentation
+        for a more detailed explanation.","default_value":"$.store.book[1].number_of_orders","attributes":[],"type":"text","is_optional":false},"source":{"human_name":"Message
+        source","additional_info":{},"description":"What to use as source field of
+        the resulting message.","default_value":"yourapi","attributes":[],"type":"text","is_optional":false}},"link_to_docs":"http://docs.graylog.org/en/2.3/pages/sending_data.html#json-path-from-http-api-input","is_exclusive":false},"org.graylog2.inputs.raw.tcp.RawTCPInput":{"type":"org.graylog2.inputs.raw.tcp.RawTCPInput","name":"Raw/Plaintext
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5555,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.tcp.GELFTCPInput":{"type":"org.graylog2.inputs.gelf.tcp.GELFTCPInput","name":"GELF
+        TCP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"use_null_delimiter":{"human_name":"Null
+        frame delimiter?","additional_info":{},"description":"Use null byte as frame
+        delimiter? Otherwise newline delimiter is used.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"max_message_size":{"human_name":"Maximum
+        message size","additional_info":{},"description":"The maximum length of a
+        message.","default_value":2097152,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.udp.RawUDPInput":{"type":"org.graylog2.inputs.raw.udp.RawUDPInput","name":"Raw/Plaintext
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5555,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.random.FakeHttpMessageInput":{"type":"org.graylog2.inputs.random.FakeHttpMessageInput","name":"Random
+        HTTP message generator","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"sleep":{"human_name":"Sleep
+        time","additional_info":{},"description":"How many milliseconds to sleep between
+        generating messages.","default_value":25,"attributes":["only_positive"],"type":"number","is_optional":false},"sleep_deviation":{"human_name":"Maximum
+        random sleep time deviation","additional_info":{},"description":"The deviation
+        is used to generate a more realistic and non-steady message flow.","default_value":30,"attributes":["only_positive"],"type":"number","is_optional":false},"source":{"human_name":"Source
+        name","additional_info":{},"description":"What to use as source of the generate
+        messages.","default_value":"example.org","attributes":[],"type":"text","is_optional":false},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.http.GELFHttpInput":{"type":"org.graylog2.inputs.gelf.http.GELFHttpInput","name":"GELF
+        HTTP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":12201,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"enable_cors":{"human_name":"Enable
+        CORS","additional_info":{},"description":"Input sends CORS headers to satisfy
+        browser security policies","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"max_chunk_size":{"human_name":"Max.
+        HTTP chunk size","additional_info":{},"description":"The maximum HTTP chunk
+        size in bytes (e. g. length of HTTP request body)","default_value":65536,"attributes":[],"type":"number","is_optional":true},"idle_writer_timeout":{"human_name":"Idle
+        writer timeout","additional_info":{},"description":"The server closes the
+        connection after the given time in seconds after the last client write request.
+        (use 0 to disable)","default_value":60,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog.plugins.beats.BeatsInput":{"type":"org.graylog.plugins.beats.BeatsInput","name":"Beats","requested_configuration":{"bind_address":{"human_name":"Bind
+        address","additional_info":{},"description":"Address to listen on. For example
+        0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":5044,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":1048576,"attributes":["only_positive"],"type":"number","is_optional":true},"tls_cert_file":{"human_name":"TLS
+        cert file","additional_info":{},"description":"Path to the TLS certificate
+        file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_key_file":{"human_name":"TLS
+        private key file","additional_info":{},"description":"Path to the TLS private
+        key file","default_value":"","attributes":[],"type":"text","is_optional":true},"tls_enable":{"human_name":"Enable
+        TLS","additional_info":{},"description":"Accept TLS connections","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"tls_key_password":{"human_name":"TLS
+        key password","additional_info":{},"description":"The password for the encrypted
+        key file.","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"tls_client_auth":{"human_name":"TLS
+        client authentication","additional_info":{"values":{"disabled":"disabled","optional":"optional","required":"required"}},"description":"Whether
+        clients need to authenticate themselves in a TLS connection","default_value":"disabled","attributes":[],"type":"dropdown","is_optional":true},"tls_client_auth_cert_file":{"human_name":"TLS
+        Client Auth Trusted Certs","additional_info":{},"description":"TLS Client
+        Auth Trusted Certs  (File or Directory)","default_value":"","attributes":[],"type":"text","is_optional":true},"tcp_keepalive":{"human_name":"TCP
+        keepalive","additional_info":{},"description":"Enable TCP keepalive packets","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.syslog.kafka.SyslogKafkaInput":{"type":"org.graylog2.inputs.syslog.kafka.SyslogKafkaInput","name":"Syslog
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"offset_reset":{"human_name":"Auto
+        offset reset","additional_info":{"values":{"largest":"Automatically reset
+        the offset to the largest offset","smallest":"Automatically reset the offset
+        to the smallest offset"}},"description":"What to do when there is no initial
+        offset in ZooKeeper or if an offset is out of range","default_value":"largest","attributes":[],"type":"dropdown","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.amqp.RawAMQPInput":{"type":"org.graylog2.inputs.raw.amqp.RawAMQPInput","name":"Raw/Plaintext
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.gelf.amqp.GELFAMQPInput":{"type":"org.graylog2.inputs.gelf.amqp.GELFAMQPInput","name":"GELF
+        AMQP","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"broker_hostname":{"human_name":"Broker
+        hostname","additional_info":{},"description":"Hostname of the AMQP broker
+        to use","default_value":"","attributes":[],"type":"text","is_optional":false},"broker_port":{"human_name":"Broker
+        port","additional_info":{},"description":"Port of the AMQP broker to use","default_value":5672,"attributes":["is_port_number"],"type":"number","is_optional":true},"broker_vhost":{"human_name":"Broker
+        virtual host","additional_info":{},"description":"Virtual host of the AMQP
+        broker to use","default_value":"/","attributes":[],"type":"text","is_optional":false},"broker_username":{"human_name":"Username","additional_info":{},"description":"Username
+        to connect to AMQP broker","default_value":"","attributes":[],"type":"text","is_optional":true},"broker_password":{"human_name":"Password","additional_info":{},"description":"Password
+        to connect to AMQP broker","default_value":"","attributes":["is_password"],"type":"text","is_optional":true},"prefetch":{"human_name":"Prefetch
+        count","additional_info":{},"description":"For advanced usage: AMQP prefetch
+        count. Default is 100.","default_value":100,"attributes":[],"type":"number","is_optional":false},"queue":{"human_name":"Queue","additional_info":{},"description":"Name
+        of queue that is created.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange":{"human_name":"Exchange","additional_info":{},"description":"Name
+        of exchange to bind to.","default_value":"log-messages","attributes":[],"type":"text","is_optional":false},"exchange_bind":{"human_name":"Bind
+        to exchange","additional_info":{},"description":"Binds the queue to the configured
+        exchange. The exchange must already exist.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"routing_key":{"human_name":"Routing
+        key","additional_info":{},"description":"Routing key to listen for.","default_value":"#","attributes":[],"type":"text","is_optional":false},"parallel_queues":{"human_name":"Number
+        of Queues","additional_info":{},"description":"Number of parallel Queues","default_value":1,"attributes":[],"type":"number","is_optional":false},"heartbeat":{"human_name":"Heartbeat
+        timeout","additional_info":{},"description":"Heartbeat interval in seconds
+        (use 0 to disable heartbeat)","default_value":60,"attributes":[],"type":"number","is_optional":true},"tls":{"human_name":"Enable
+        TLS?","additional_info":{},"description":"Enable transport encryption via
+        TLS. (requires valid TLS port setting)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"requeue_invalid_messages":{"human_name":"Re-queue
+        invalid messages?","additional_info":{},"description":"Invalid messages will
+        be discarded if disabled.","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"decompress_size_limit":{"human_name":"Decompressed
+        size limit","additional_info":{},"description":"The maximum number of bytes
+        after decompression.","default_value":8388608,"attributes":[],"type":"number","is_optional":true}},"link_to_docs":"","is_exclusive":false},"org.graylog2.inputs.raw.kafka.RawKafkaInput":{"type":"org.graylog2.inputs.raw.kafka.RawKafkaInput","name":"Raw/Plaintext
+        Kafka","requested_configuration":{"throttling_allowed":{"human_name":"Allow
+        throttling this input.","additional_info":{},"description":"If enabled, no
+        new messages will be read from this input until Graylog catches up with its
+        message load. This is typically useful for inputs reading from files or message
+        queue systems like AMQP or Kafka. If you regularly poll an external system,
+        e.g. via HTTP, you normally want to leave this disabled.","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"zookeeper":{"human_name":"ZooKeeper
+        address","additional_info":{},"description":"Host and port of the ZooKeeper
+        that is managing your Kafka cluster.","default_value":"127.0.0.1:2181","attributes":[],"type":"text","is_optional":false},"topic_filter":{"human_name":"Topic
+        filter regex","additional_info":{},"description":"Every topic that matches
+        this regular expression will be consumed.","default_value":"^your-topic$","attributes":[],"type":"text","is_optional":false},"fetch_min_bytes":{"human_name":"Fetch
+        minimum bytes","additional_info":{},"description":"Wait for a message batch
+        to reach at least this size or the configured maximum wait time before fetching.","default_value":5,"attributes":[],"type":"number","is_optional":false},"fetch_wait_max":{"human_name":"Fetch
+        maximum wait time (ms)","additional_info":{},"description":"Wait for this
+        time or the configured minimum size of a message batch before fetching.","default_value":100,"attributes":[],"type":"number","is_optional":false},"threads":{"human_name":"Processor
+        threads","additional_info":{},"description":"Number of processor threads to
+        spawn. Use one thread per Kafka topic partition.","default_value":2,"attributes":[],"type":"number","is_optional":false},"offset_reset":{"human_name":"Auto
+        offset reset","additional_info":{"values":{"largest":"Automatically reset
+        the offset to the largest offset","smallest":"Automatically reset the offset
+        to the smallest offset"}},"description":"What to do when there is no initial
+        offset in ZooKeeper or if an offset is out of range","default_value":"largest","attributes":[],"type":"dropdown","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true}},"link_to_docs":"","is_exclusive":false}}'
+    http_version: 
+  recorded_at: Wed, 11 Oct 2017 19:07:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/get_input_by_type/code_200.yml
+++ b/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/get_input_by_type/code_200.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9000/api/system/inputs/types/org.graylog2.inputs.syslog.udp.SyslogUDPInput
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Graylog-Node-Id:
+      - f400dd86-7ae8-4483-a100-659a1f0f3310
+      X-Runtime-Microseconds:
+      - '34851'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 11 Oct 2017 19:07:10 GMT
+      Content-Length:
+      - '2107'
+    body:
+      encoding: UTF-8
+      string: '{"type":"org.graylog2.inputs.syslog.udp.SyslogUDPInput","name":"Syslog
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false}'
+    http_version: 
+  recorded_at: Wed, 11 Oct 2017 19:07:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/get_input_by_type/contain_name.yml
+++ b/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/get_input_by_type/contain_name.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9000/api/system/inputs/types/org.graylog2.inputs.syslog.udp.SyslogUDPInput
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Graylog-Node-Id:
+      - f400dd86-7ae8-4483-a100-659a1f0f3310
+      X-Runtime-Microseconds:
+      - '2686'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 11 Oct 2017 19:07:10 GMT
+      Content-Length:
+      - '2107'
+    body:
+      encoding: UTF-8
+      string: '{"type":"org.graylog2.inputs.syslog.udp.SyslogUDPInput","name":"Syslog
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false}'
+    http_version: 
+  recorded_at: Wed, 11 Oct 2017 19:07:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/get_input_by_type/contain_type.yml
+++ b/spec/fixtures/vcr/GraylogAPI_System_Inputs_Types/get_input_by_type/contain_type.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9000/api/system/inputs/types/org.graylog2.inputs.syslog.udp.SyslogUDPInput
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46YWRtaW4=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Graylog-Node-Id:
+      - f400dd86-7ae8-4483-a100-659a1f0f3310
+      X-Runtime-Microseconds:
+      - '3563'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 11 Oct 2017 19:07:10 GMT
+      Content-Length:
+      - '2107'
+    body:
+      encoding: UTF-8
+      string: '{"type":"org.graylog2.inputs.syslog.udp.SyslogUDPInput","name":"Syslog
+        UDP","requested_configuration":{"bind_address":{"human_name":"Bind address","additional_info":{},"description":"Address
+        to listen on. For example 0.0.0.0 or 127.0.0.1.","default_value":"0.0.0.0","attributes":[],"type":"text","is_optional":false},"port":{"human_name":"Port","additional_info":{},"description":"Port
+        to listen on.","default_value":514,"attributes":["is_port_number"],"type":"number","is_optional":false},"recv_buffer_size":{"human_name":"Receive
+        Buffer Size","additional_info":{},"description":"The size in bytes of the
+        recvBufferSize for network connections to this input.","default_value":262144,"attributes":["only_positive"],"type":"number","is_optional":true},"override_source":{"human_name":"Override
+        source","additional_info":{},"description":"The source is a hostname derived
+        from the received packet by default. Set this if you want to override it with
+        a custom string.","default_value":null,"attributes":[],"type":"text","is_optional":true},"force_rdns":{"human_name":"Force
+        rDNS?","additional_info":{},"description":"Force rDNS resolution of hostname?
+        Use if hostname cannot be parsed. (Be careful if you are sending DNS logs
+        into this input because it can cause a feedback loop.)","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"allow_override_date":{"human_name":"Allow
+        overriding date?","additional_info":{},"description":"Allow to override with
+        current date if date could not be parsed?","default_value":true,"attributes":[],"type":"boolean","is_optional":true},"store_full_message":{"human_name":"Store
+        full message?","additional_info":{},"description":"Store the full original
+        syslog message as full_message?","default_value":false,"attributes":[],"type":"boolean","is_optional":true},"expand_structured_data":{"human_name":"Expand
+        structured data?","additional_info":{},"description":"Expand structured data
+        elements by prefixing attributes with their SD-ID?","default_value":false,"attributes":[],"type":"boolean","is_optional":true}},"link_to_docs":"","is_exclusive":false}'
+    http_version: 
+  recorded_at: Wed, 11 Oct 2017 19:07:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/graylog_api/system/inputs/types_spec.rb
+++ b/spec/graylog_api/system/inputs/types_spec.rb
@@ -29,7 +29,7 @@ describe GraylogAPI::System::Inputs::Types, vcr: true do
     end
   end
 
-  context 'get by inputType' do
+  context 'get input by type' do
     subject(:response) do
       graylogapi.system.inputs.types.by_type(type)
     end
@@ -47,6 +47,19 @@ describe GraylogAPI::System::Inputs::Types, vcr: true do
 
     it 'contain name' do
       expect(response['name']).to eq name
+    end
+  end
+
+  context 'converge type_id to type_name' do
+    subject(:response) do
+      graylogapi.system.inputs.types.type_to_name(type)
+    end
+
+    let(:type) { 'org.graylog2.inputs.syslog.udp.SyslogUDPInput' }
+    let(:name) { 'Syslog UDP' }
+
+    it 'return type name' do
+      expect(response).to eq name
     end
   end
 end


### PR DESCRIPTION
You can converge type_id to type name

Example:
```
graylogapi.system.inputs.types.type_to_name('org.graylog2.inputs.syslog.udp.SyslogUDPInput')
# => 'Syslog UDP'
```